### PR TITLE
Add ->reversed method

### DIFF
--- a/lib/Bio/Cigar.pm
+++ b/lib/Bio/Cigar.pm
@@ -186,6 +186,12 @@ Takes a query position and returns the operation at that position.  Simply
 a shortcut for calling L</qpos_to_rpos> in list context and discarding the
 first return value.
 
+=head2 reversed
+
+Returns a new Bio::Cigar object with a CIGAR string that's the reverse of this
+one, i.e. the last operation becomes the first, the second-to-last the second,
+etc. until the first operation becomes the last.
+
 =cut
 
 # Consumption table based on
@@ -296,6 +302,11 @@ sub op_at_qpos {
     my $self = shift;
     my ($rpos, $type) = $self->qpos_to_rpos(@_);
     return $type;
+}
+
+sub reversed {
+    my $self = shift;
+    return Bio::Cigar->new(join "", map { join "", @$_ } reverse @{$self->ops});
 }
 
 =head1 AUTHOR

--- a/t/basic.t
+++ b/t/basic.t
@@ -138,4 +138,11 @@ use Bio::Cigar;
     like $@, qr/qpos = 13 is < 1 or > query_length \(12\)/, "exception wording";
 }
 
+# Reversed
+{
+    my $cigar = Bio::Cigar->new("2S4M2I4M3H");
+    is $cigar->string, "2S4M2I4M3H", "string matches";
+    is $cigar->reversed->string, "3H4M2I4M2S", "string matches";
+}
+
 done_testing;


### PR DESCRIPTION
Motivated by <https://github.com/MullinsLab/Bio-Cigar/issues/2>.

May be useful for normalizing CIGAR direction based on external information about alignment/read mapping?

---

Not sure if anyone in Mullins Lab is maintaining this, but I can cut a new CPAN release if not.